### PR TITLE
Add hostapd to depends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-hotspot (1.0.1+nmu2) unstable; urgency=medium
+
+  * Add hostapd to depends 
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Wed, 29 Dec 2021 16:30:35 -0500
+
 wlanpi-hotspot (1.0.1+nmu1) unstable; urgency=medium
 
   * Fix install

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,8 @@ Homepage: https://github.com/WLAN-Pi/wlanpi-hotspot
 Package: wlanpi-hotspot
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         hostapd
 Description: WLAN Pi simple hotspot
  WLAN Pi simple hotspot.


### PR DESCRIPTION
Add hostapd to depends so that `apt` will automatically install hostapd if it is missing.